### PR TITLE
Updates the module to work with Log In with PayPal

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -35,7 +35,7 @@ passport.use(new PayPalStrategy({
   function(accessToken, refreshToken, profile, done) {
     // asynchronous verification, for effect...
     process.nextTick(function () {
-      
+
       // To keep the example simple, the user's PayPal profile is returned to
       // represent the logged-in user.  In a typical application, you would want
       // to associate the PayPal account with a user record in your database,
@@ -86,7 +86,7 @@ app.get('/login', function(req, res){
 //   redirecting the user to paypal.com.  After authorization, PayPal will
 //   redirect the user back to this application at /auth/paypal/callback
 app.get('/auth/paypal',
-  passport.authenticate('paypal', { scope: 'https://identity.x.com/xidentity/resources/profile/me' }),
+  passport.authenticate('paypal', { scope: 'openid profile email' }),
   function(req, res){
     // The request will be redirected to PayPal for authentication, so this
     // function will not be called.
@@ -97,7 +97,7 @@ app.get('/auth/paypal',
 //   request.  If authentication fails, the user will be redirected back to the
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
-app.get('/auth/paypal/callback', 
+app.get('/auth/paypal/callback',
   passport.authenticate('paypal', { failureRedirect: '/login' }),
   function(req, res) {
     res.redirect('/');

--- a/lib/passport-paypal-oauth/strategy.js
+++ b/lib/passport-paypal-oauth/strategy.js
@@ -42,13 +42,13 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://identity.x.com/xidentity/resources/authorize';
-  options.tokenURL = options.tokenURL || 'https://identity.x.com/xidentity/oauthtokenservice';
-  
+  options.authorizationURL = options.authorizationURL || 'https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize';
+  options.tokenURL = options.tokenURL || 'https://api.paypal.com/v1/identity/openidconnect/tokenservice';
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'paypal';
-  
-  this._oauth2.setAccessTokenName("oauth_token");
+
+  this._oauth2.setAccessTokenName("access_token");
 }
 
 /**
@@ -71,26 +71,24 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.getProtectedResource('https://identity.x.com/xidentity/resources/profile/me', accessToken, function (err, body, res) {
+  this._oauth2.get('https://api.paypal.com/v1/identity/openidconnect/userinfo/?schema=openid', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'paypal' };
-      profile.id = json.identity.userId;
-      profile.displayName = json.identity.firstName + " " + json.identity.lastName;
-      profile.name = { familyName: json.identity.lastName,
-                       givenName: json.identity.firstName,
-                       formatted: json.identity.fullName };
+      profile.id = json.user_id;
+      profile.displayName = json.name;
+      profile.name = { familyName: json.family_name,
+                       givenName: json.given_name,
+                       formatted: json.name };
       profile.emails = [];
-      json.identity.emails.forEach(function(email) {
-        profile.emails.push({ value: email });
-      });
-      
+      profile.emails.push({ value: json.email });
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);

--- a/lib/passport-paypal-oauth/strategy.js
+++ b/lib/passport-paypal-oauth/strategy.js
@@ -44,6 +44,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize';
   options.tokenURL = options.tokenURL || 'https://api.paypal.com/v1/identity/openidconnect/tokenservice';
+  this.profileURL = options.profileURL || 'https://api.paypal.com/v1/identity/openidconnect/userinfo/?schema=openid';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'paypal';
@@ -71,7 +72,7 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get('https://api.paypal.com/v1/identity/openidconnect/userinfo/?schema=openid', accessToken, function (err, body, res) {
+  this._oauth2.get(this.profileURL, accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
 
     try {


### PR DESCRIPTION
PayPal Access has been updated this year to become Log In with PayPal.
This PR does all the necessary changes to work with the new OAuth 2.0 / OpenID Connect flow according to https://developer.paypal.com/webapps/developer/docs/integration/direct/log-in-with-paypal/.

It does update the minimum scope in the sample but shouldn't have any negative effects.
